### PR TITLE
Keeping the compatibility with python2.7

### DIFF
--- a/SkyPy/util.py
+++ b/SkyPy/util.py
@@ -48,10 +48,13 @@ def initAttrs(cls):
     setattr(cls, "__init__", __init__)
     return cls
 
-def convertIds(*types, user=(), users=(), chat=()):
+def convertIds(*types, **kwargs):
     """
     Class decorator: add helper methods to convert identifier properties into SkypeObjs.
     """
+    user = kwargs.get('user',())
+    users = kwargs.get('users', ())
+    chat = kwargs.get('chat', ())
     def userObj(self, field):
         """
         Retrieve the user referred to in the object.


### PR DESCRIPTION
Seems like the rest of the code works just fine with python2.7 so I'd like to keep the compatibility with 2.7 by rewriting class decorator a bit differently.
Otherwise it breaks it for python 2.7 users. More info:
https://www.python.org/dev/peps/pep-3102/