### PR TITLE
Resubscribe on 400/404 for setting presence.

### DIFF
--- a/SkyPy/core.py
+++ b/SkyPy/core.py
@@ -164,6 +164,7 @@ class Skype(object):
                               auth=SkypeConnection.Auth.Reg).json().get("eventMessages", []):
             events.append(SkypeEvent.fromRaw(self, json))
         return events
+    @resubscribeOn(400, 404)
     def setPresence(self, online=True):
         """
         Set the user's presence (either Online or Hidden).


### PR DESCRIPTION
Most of the times we want to set presence to online on startup/login and when reusing the token it gives 404 or 400 if we try to set the presence, so makes sense to resubscribe in those cases.